### PR TITLE
fix: color of selected country in footer

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,11 @@
 # Contributing Guidelines
 
-This is a GatsbyJS site, on top of Netlify CMS for now, and powered by YAML files.
+This is a GatsbyJS site, on top of Netlify CMS for now, and powered by YAML files. It's easy to start hacking. All you need is to
+
+1. Fork the repo
+1. `yarn` to fetch dependencies
+1. `yarn start` to spin up dev server on localhost:8000
+1. Update, commit, push to your fork. And open a pull request
 
 Swing by `src/data/links/` to see all the links, and if you'd like to add a new one just copy and paste one of the older ones and update it.
 

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -67,7 +67,6 @@ const Footer = () => {
                     {Countries.fromAlpha2Code(country.code).emoji}{' '}
                     {country.name}
                   </span>{' '}
-                  <span>&middot;</span>
                 </>
               ) : null}
               <Button href="/select-your-country" className="link text-white">

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -17,6 +17,13 @@ blockquote p {
   display: inline;
 }
 
+// Ensure the selected country is
+// readable on the #333 footer.
+.change-country .current {
+  color: white;
+  margin-bottom: 20px;
+}
+
 /* Select Your Country */
 .select-your-country {
   max-width: 768px;


### PR DESCRIPTION
When selected, the country is difficult to read in the footer:

<img width="152" alt="Screen Shot 2020-10-18 at 7 55 15 AM" src="https://user-images.githubusercontent.com/1530684/96371604-44230d80-1117-11eb-9bad-af11b31bdf23.png">

This is a tiny PR to make the selected color white.

Also,

- Added install instructions to `CONTRIBUTING.md`
- Removed extraneous period from selected country (was a subjective call; happy to back this out if undesired!)

This project is fantastic and I'm a big fan. @ maintainers, would it be possible for me to get push permissions so that I don't need to fork the repo to contribute?